### PR TITLE
Fix calendar search and filter tools not finding events

### DIFF
--- a/test_calendar_fix.py
+++ b/test_calendar_fix.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""
+Test script to verify calendar search/filter fixes
+"""
+
+import subprocess
+import json
+import sys
+
+def run_command(cmd):
+    """Run a command and return the output"""
+    result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    return result.stdout, result.stderr, result.returncode
+
+def test_calendar_filter():
+    """Test calendar filtering"""
+    print("Testing calendar filter...")
+    cmd = 'py python/outlook_filter.py "connor.larson@outlook.com/Calendar" --days 30 --type event'
+    stdout, stderr, code = run_command(cmd)
+    
+    if code != 0:
+        print(f"  [FAIL] Filter failed: {stderr}")
+        return False
+    
+    try:
+        data = json.loads(stdout)
+        if data['total'] > 0:
+            print(f"  [PASS] Found {data['total']} calendar events")
+            # Check if we found known events
+            subjects = [r['subject'] for r in data['results']]
+            if any('CoffeeRun' in s for s in subjects):
+                print(f"  [PASS] Found CoffeeRun event")
+            return True
+        else:
+            print(f"  [WARN] No calendar events found")
+            return False
+    except json.JSONDecodeError:
+        print(f"  [FAIL] Invalid JSON output")
+        return False
+
+def test_calendar_search():
+    """Test calendar search"""
+    print("\nTesting calendar search...")
+    cmd = 'py python/outlook_search.py "Monday" "connor.larson@outlook.com/Calendar"'
+    stdout, stderr, code = run_command(cmd)
+    
+    if code != 0:
+        print(f"  [FAIL] Search failed: {stderr}")
+        return False
+    
+    # Check for the error that was happening before
+    if "ReceivedTime" in stderr and "unknown" in stderr:
+        print(f"  [FAIL] Still using ReceivedTime for calendar: {stderr}")
+        return False
+    
+    try:
+        data = json.loads(stdout)
+        if data['pagination']['total'] > 0:
+            print(f"  [PASS] Found {data['pagination']['total']} items matching 'Monday'")
+            return True
+        else:
+            print(f"  [WARN] No items found for 'Monday'")
+            return False
+    except json.JSONDecodeError:
+        print(f"  [FAIL] Invalid JSON output")
+        return False
+
+def test_email_regression():
+    """Ensure email functionality still works"""
+    print("\nTesting email functionality (regression check)...")
+    
+    # Test email filter
+    cmd = 'py python/outlook_filter.py "connor.larson@outlook.com/Inbox" --days 30'
+    stdout, stderr, code = run_command(cmd)
+    
+    if code != 0:
+        print(f"  [FAIL] Email filter failed: {stderr}")
+        return False
+    
+    try:
+        data = json.loads(stdout)
+        print(f"  [PASS] Email filter works: {data['total']} emails in Inbox")
+    except:
+        print(f"  [FAIL] Email filter output invalid")
+        return False
+    
+    # Test email search
+    cmd = 'py python/outlook_search.py "meeting" "connor.larson@outlook.com/Sent Items"'
+    stdout, stderr, code = run_command(cmd)
+    
+    if code != 0:
+        print(f"  [FAIL] Email search failed: {stderr}")
+        return False
+    
+    try:
+        data = json.loads(stdout)
+        print(f"  [PASS] Email search works: {data['pagination']['total']} results")
+        return True
+    except:
+        print(f"  [FAIL] Email search output invalid")
+        return False
+
+def main():
+    print("=" * 50)
+    print("CALENDAR FIX VERIFICATION TEST SUITE")
+    print("=" * 50)
+    
+    tests_passed = 0
+    tests_total = 3
+    
+    if test_calendar_filter():
+        tests_passed += 1
+    
+    if test_calendar_search():
+        tests_passed += 1
+    
+    if test_email_regression():
+        tests_passed += 1
+    
+    print("\n" + "=" * 50)
+    print(f"RESULTS: {tests_passed}/{tests_total} tests passed")
+    
+    if tests_passed == tests_total:
+        print("[PASS] All tests passed! Calendar fix is working correctly.")
+        return 0
+    else:
+        print("[FAIL] Some tests failed. Please review the output above.")
+        return 1
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Fixed calendar search and filter tools to properly handle recurring events
- Tools now correctly find events like CoffeeRun BBQ and Monday Trailfun runs
- No regression in email functionality

## Root Cause
The tools were missing critical calendar-specific logic:
1. Not setting `IncludeRecurrences = True` for calendar folders (required for recurring events)
2. Using wrong date field (`[ReceivedTime]` instead of `[Start]` for calendar items)
3. Not detecting calendar folders to apply calendar-specific behavior

## Changes
- **outlook_filter.py**: Detect calendar folders, enable recurrences, use Start field for dates
- **outlook_search.py**: Same fixes plus proper date field in DASL queries
- **test_calendar_fix.py**: Comprehensive test suite to verify the fix

## Test Results
```
CALENDAR FIX VERIFICATION TEST SUITE
==================================================
Testing calendar filter...
  [PASS] Found 88 calendar events
  [PASS] Found CoffeeRun event

Testing calendar search...
  [PASS] Found 112 items matching 'Monday'

Testing email functionality (regression check)...
  [PASS] Email filter works: 7 emails in Inbox
  [PASS] Email search works: 29 results

==================================================
RESULTS: 3/3 tests passed
```

Fixes #10